### PR TITLE
Score comparison tool: avoid crash on inability to merge text diffs

### DIFF
--- a/libmscore/chordrest.cpp
+++ b/libmscore/chordrest.cpp
@@ -177,14 +177,18 @@ void ChordRest::writeProperties(XmlWriter& xml) const
 
       for (Lyrics* lyrics : _lyrics)
             lyrics->write(xml);
+
+      const int curTick = xml.curTick().ticks();
+
       if (!isGrace()) {
             Fraction t(globalTicks());
             if (staff())
                   t /= staff()->timeStretch(xml.curTick());
             xml.incCurTick(t);
             }
-      for (auto i : score()->spanner()) {     // TODO: don’t search whole list
-            Spanner* s = i.second;
+
+      for (auto i : score()->spannerMap().findOverlapping(curTick - 1, curTick + 1)) {
+            Spanner* s = i.value;
             if (s->generated() || !s->isSlur() || toSlur(s)->broken() || !xml.canWrite(s))
                   continue;
 

--- a/libmscore/score.h
+++ b/libmscore/score.h
@@ -789,7 +789,7 @@ class Score : public QObject, public ScoreElement {
 
       bool saveFile(QFileInfo& info);
       bool saveFile(QIODevice* f, bool msczFormat, bool onlySelection = false);
-      bool saveCompressedFile(QFileInfo&, bool onlySelection);
+      bool saveCompressedFile(QFileInfo&, bool onlySelection, bool createThumbnail = true);
       bool saveCompressedFile(QFileDevice*, QFileInfo&, bool onlySelection, bool createThumbnail = true);
 
       void print(QPainter* printer, int page);

--- a/libmscore/scorediff.cpp
+++ b/libmscore/scorediff.cpp
@@ -403,14 +403,17 @@ int MscxModeDiff::performShiftDiff(std::vector<TextDiff>& diffs, int index, int 
       std::copy(chunkEnd, chunkEnd + 2, eqDiff.end);
 
       const int prevDiffIdx = index + (down ? -1 : 1);
+      bool merged = false;
       if (diffs[prevDiffIdx].type == DiffType::EQUAL)
-            diffs[prevDiffIdx].merge(eqDiff);
-      else {
+            merged = diffs[prevDiffIdx].merge(eqDiff);
+
+      if (!merged) {
             const int insertIdx = down ? index : (index + 1);
             diffs.insert(diffs.begin() + insertIdx, eqDiff);
             if (down)
                   ++index;
             }
+
       return index;
       }
 
@@ -1170,7 +1173,7 @@ QString ScoreDiff::userDiff() const
 //   TextDiff::merge
 //---------------------------------------------------------
 
-void TextDiff::merge(const TextDiff& other)
+bool TextDiff::merge(const TextDiff& other)
       {
       if (type == other.type) {
             if (other.end[0] == (start[0] - 1) && other.end[1] == (start[1] - 1)) {
@@ -1185,8 +1188,10 @@ void TextDiff::merge(const TextDiff& other)
                   text[0].append(other.text[0]);
                   text[1].append(other.text[1]);
                   }
-            else
-                  qFatal("TextDiff:merge: invalid argument: wrong line numbers");
+            else {
+                  qWarning("TextDiff:merge: invalid argument: wrong line numbers");
+                  return false;
+                  }
             }
       else if ((type == DiffType::INSERT && other.type == DiffType::DELETE)
          || (type == DiffType::DELETE && other.type == DiffType::INSERT)
@@ -1197,8 +1202,12 @@ void TextDiff::merge(const TextDiff& other)
             end[iOther] = other.end[iOther];
             text[iOther] = other.text[iOther];
             }
-      else
-            qFatal("TextDiff:merge: invalid argument: wrong types");
+      else {
+            qWarning("TextDiff:merge: invalid argument: wrong types");
+            return false;
+            }
+
+      return true;
       }
 
 //---------------------------------------------------------

--- a/libmscore/scorediff.h
+++ b/libmscore/scorediff.h
@@ -56,7 +56,7 @@ struct TextDiff {
       int start[2]; // starting line numbers in both texts
       int end[2];   // ending line numbers in both texts
 
-      void merge(const TextDiff& other); // merge other diff into this one
+      bool merge(const TextDiff& other); // merge other diff into this one
       QString toString(DiffType type, bool prefixLines = false) const;
       QString toString(bool prefixLines = false) const { return toString(type, prefixLines); }
       };

--- a/libmscore/scorefile.cpp
+++ b/libmscore/scorefile.cpp
@@ -486,7 +486,7 @@ bool MasterScore::saveFile()
 //   saveCompressedFile
 //---------------------------------------------------------
 
-bool Score::saveCompressedFile(QFileInfo& info, bool onlySelection)
+bool Score::saveCompressedFile(QFileInfo& info, bool onlySelection, bool createThumbnail)
       {
       if (readOnly() && info == *masterScore()->fileInfo())
             return false;
@@ -495,7 +495,7 @@ bool Score::saveCompressedFile(QFileInfo& info, bool onlySelection)
             MScore::lastError = tr("Open File\n%1\nfailed: %2").arg(info.filePath(), strerror(errno));
             return false;
             }
-      return saveCompressedFile(&fp, info, onlySelection);
+      return saveCompressedFile(&fp, info, onlySelection, createThumbnail);
       }
 
 //---------------------------------------------------------

--- a/mscore/musescore.cpp
+++ b/mscore/musescore.cpp
@@ -5039,7 +5039,7 @@ void MuseScore::autoSaveTimerTimeout()
                   if (!tmp.isEmpty()) {
                         QFileInfo fi(tmp);
                         // TODO: cannot catch exception here:
-                        s->saveCompressedFile(fi, false);
+                        s->saveCompressedFile(fi, false, false); // no thumbnail
                         }
                   else {
                         QDir dir;


### PR DESCRIPTION
Calling merge() on non-adjacent text diffs should probably not happen
and reveals a potential bug in score diff code, but it is not a fatal
error and should not lead to MuseScore crash. This commit avoids
terminating MuseScore in this case. Score comparison still produces
sensible results in case of such error.

Resolves: *(direct link to the issue)*

*(short description of the changes and the motivation to make the changes)*

<!-- Use "x" to fill the checkboxes below like [x] -->

- [ ] I signed [CLA](https://musescore.org/en/cla)
- [ ] I made sure the code in the PR follows [the coding rules](https://musescore.org/en/handbook/developers-handbook/finding-your-way-around/musescore-coding-rules)
- [ ] I made sure the code compiles on my machine
- [ ] I made sure there are no unnecessary changes in the code
- [ ] I made sure the title of the PR reflects the core meaning of the issue you are solving
- [ ] I made sure the commit message(s) contain a description and answer the question "Why do those changes fix that particular issue?" or "Why are those changes really necessary as improvements?"
- [ ] I made sure the commit message title starts with "fix #424242:" if there is a related issue
- [ ] I created the test (mtest, vtest, script test) to verify the changes I made
